### PR TITLE
Use implicit executable dependency for gen_bytes0.exe

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -4,5 +4,5 @@
   (pps ppx_js_style -check-doc-comments ppx_compare ppx_sexp_conv
    -deriving-keep-w32=impl)))
 
-(rule (targets bytes0.ml) (deps (:first_dep gen/gen_bytes0.exe))
- (action (bash "./%{first_dep} > %{targets}")))
+(rule (targets bytes0.ml)
+ (action (with-stdout-to %{targets} (run ./gen/gen_bytes0.exe))))


### PR DESCRIPTION
Explicit executable dependencies make dune fail in cross-compilation settings.
More info in ocaml/dune#3917.